### PR TITLE
fixed a broken link in the readme (CONTRIBUTING.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ View the project roadmap [here](LINK_TO_PROJECT_ISSUES)
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+See [_CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ View the project roadmap [here](LINK_TO_PROJECT_ISSUES)
 
 ## Contributing
 
-See [_CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+See [CONTRIBUTING.md](_CONTRIBUTING.md) for contribution guidelines.


### PR DESCRIPTION
The link to CONTRIBUTING.md was a 404. I added the needed '_' character to fix the link to direct to the correct page.
